### PR TITLE
Allow MiData group ids as code

### DIFF
--- a/src/getonedivision.php
+++ b/src/getonedivision.php
@@ -28,7 +28,7 @@ function getCodeFromURL() {
   if (isset($_GET['code'])) {
 
 	  // Check if input is secure
-    $match = preg_match('/^[a-zA-Z]{1,3}\d{1,3}$/', $_GET['code']);
+    $match = preg_match('/^[a-zA-Z]{0,3}\d{1,4}$/', $_GET['code']);
     if($match === 1) return $_GET['code'];
   }	
 }


### PR DESCRIPTION
Der Code kann auch eine Gruppen-ID aus der MiData sein. Deshalb sollten Codes mit 1-4 stelligen Zahlen auch erlaubt sein.