### PR TITLE
feat: add description field to divisions

### DIFF
--- a/src/division.php
+++ b/src/division.php
@@ -108,7 +108,8 @@ function transformDivisionData($data) {
     'locations' => $data['linked']['geolocations'],
     'social_accounts' => $data['linked']['social_accounts'],
     'id' => intval($division['id']),
-    'deleted_at' => $division['deleted_at']
+    'deleted_at' => $division['deleted_at'],
+    'description' => $division['description']
   ];
 }
 

--- a/src/migrate.php
+++ b/src/migrate.php
@@ -11,5 +11,10 @@ function addPbsId($connection) {
   $connection->query("ALTER TABLE `locations` ADD pbs_id INT(11) UNSIGNED;");
 }
 
+function addDescription($connection) {
+  $connection->query("ALTER TABLE `divisions` ADD description VARCHAR(255) NULL;");
+}
+
 addUpdatedAt(connect($config));
 addPbsId(connect($config));
+addDescription(connect($config));


### PR DESCRIPTION
The description field enables divisions to indicate whether or not they are accepting new members.

Right now, divisions show up on the pfadi-finder whether or not they are still accepting new members and there is no option to indicate if they are.